### PR TITLE
demo tweaks: timezone warning & sub-second sleeps

### DIFF
--- a/demo/demo.php
+++ b/demo/demo.php
@@ -1,5 +1,7 @@
 <?
 
+date_default_timezone_set("UTC");
+
 require "../profiler.php";
 Profiler::enable();
 
@@ -10,19 +12,19 @@ ProfilerRenderer::setPrettifyLocation("../code-prettify");
 
 $s1 = Profiler::start('Step 1');
 //do some important things!
-sleep(.5);
+usleep(500000);  // 0.5 sec
 $s1->end();
 
 $s2 = Profiler::start('Step 2');
 //more important things
-sleep(.1);
+usleep(100000);  // 0.1 sec
 	
 	$s3 = Profiler::start('Step 3');
 	//some nested things..that are important and stuff.
 	sleep(1);
 
 	$sql = Profiler::sqlStart("SELECT * FROM TABLE WHERE 1");
-	sleep(1.5);
+	usleep(1500000);  // 1.5 sec
 	$sql->end();
 	
 	$s3->end();


### PR DESCRIPTION
1) Everyone's favorite warning shows up in the popup in the demo app: _Warning: date(): It is not safe to rely on the system's timezone settings. You are required to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone._

2) sleep() actually takes an integer, usleep() is required for sub-second precision.

Awesome project, btw. :)
