### PR TITLE
debug_backtrace() in PHP < 5.2.4 doesn't support parameters.

### DIFF
--- a/profiler.php
+++ b/profiler.php
@@ -948,7 +948,7 @@ class ProfilerSQLNode
 		$this->query = $query;
 		$this->profileNode = $profileNode;
 		
-		$this->callstack = debug_backtrace(false);
+		$this->callstack = debug_backtrace();
 		array_shift($this->callstack);
 		array_shift($this->callstack);
 	}


### PR DESCRIPTION
Older versions of PHP don't support parameters for debug_backtrace(),
and it throws an error if the level is high enough.
