### PR TITLE
Set the right path for $prettifyLocation

### DIFF
--- a/profiler.php
+++ b/profiler.php
@@ -1190,7 +1190,9 @@ class ProfilerRenderer
 	 */
 	public static function getPrettifyLocation()
 	{
-		return self::$prettifyLocation;
+		$relative_path = str_replace($_SERVER['DOCUMENT_ROOT'], "", __DIR__);
+		
+		return $relative_path . self::$prettifyLocation;
 	}
 	
 	/**


### PR DESCRIPTION
Some times (like in my case) you want the code in a subdir and then the location is wrong.
I added the relative path from the ServerRoot to the profiler.php as prefix to the current location.
